### PR TITLE
update readme.rdoc for actual class location.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,7 +12,7 @@ You will now be able to access those keys through underscored key names (camelCa
 
 == Usage
 
-  @rash = Hashie::Rash.new({
+  @rash = Hashie::Hash::Rash.new({
     "varOne" => 1,
     "two" => 2,
     :three => 3,


### PR DESCRIPTION
Hashie::Rash moved to Hashie::Hash::Rash to avoid a name conflict with Hashie's new Hashie::Rash
